### PR TITLE
remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "whichbrowser/parser",
-    "version": "2.0.12",
 
     "description": "Useragent sniffing library for PHP",
     "keywords": ["useragent","browser","sniffing", "ua"],


### PR DESCRIPTION
For `packagist` the `release` version is enough.

So you dont need to edit it each released version

see for example
https://github.com/ThaDafinser/UserAgentParser/blob/master/composer.json
https://packagist.org/packages/thadafinser/user-agent-parser