### PR TITLE
Add more semantic constructors

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -25,6 +25,28 @@ class Parser extends Main
     }
 
     /**
+     * Create a new Parser instance from a user agent string
+     *
+     * @param  string   $agent     Required, a string containing the raw User-Agent
+     * @param  array    $options   Optional, an array with configuration options
+     */
+    public static function fromUserAgent($agent, array $options = [])
+    {
+        return new static($agent, $options);
+    }
+
+    /**
+     * Create a new Parser instance from a user agent string
+     *
+     * @param  array    $headers    Required, an array with all of the headers
+     * @param  array    $options    Optional, an array with configuration options
+     */
+    public static function fromHeaders(array $headers, array $options = [])
+    {
+        return new static($headers, $options);
+    }
+
+    /**
      * Analyse the provided headers or User-Agent string
      *
      * @param  array|string   $headers   An array with all of the headers or a string with just the User-Agent header

--- a/tests/unit/ParserTest.php
+++ b/tests/unit/ParserTest.php
@@ -40,10 +40,27 @@ class ParserTest extends PHPUnit_Framework_TestCase
     {
         $parser = new Parser();
         $parser->analyse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)");
-        
+
+        $this->assertTrue($parser->isBrowser('Internet Explorer', '=', '6.0'));
+    }
+
+    public function testCreatingParserFromUserAgent()
+    {
+        $parser = Parser::fromUserAgent('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)');
+
         $this->assertTrue($parser instanceof \WhichBrowser\Parser);
 
         $this->assertTrue($parser->isBrowser('Internet Explorer', '=', '6.0'));
     }
 
+    public function testCreatingParserFromHeaderArray()
+    {
+        $parser = Parser::fromHeaders([
+            'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)'
+        ]);
+
+        $this->assertTrue($parser instanceof \WhichBrowser\Parser);
+
+        $this->assertTrue($parser->isBrowser('Internet Explorer', '=', '6.0'));
+    }
 }

--- a/tests/unit/ParserTest.php
+++ b/tests/unit/ParserTest.php
@@ -13,8 +13,6 @@ class ParserTest extends PHPUnit_Framework_TestCase
     {
         $parser = new Parser("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)");
 
-        $this->assertTrue($parser instanceof \WhichBrowser\Parser);
-
         $this->assertTrue($parser->isBrowser('Internet Explorer', '=', '6.0'));
     }
 
@@ -23,8 +21,6 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $parser = new Parser([
             'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)'
         ]);
-
-        $this->assertTrue($parser instanceof \WhichBrowser\Parser);
 
         $this->assertTrue($parser->isBrowser('Internet Explorer', '=', '6.0'));
     }
@@ -36,8 +32,6 @@ class ParserTest extends PHPUnit_Framework_TestCase
                 'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)'
             ]
         ]);
-
-        $this->assertTrue($parser instanceof \WhichBrowser\Parser);
 
         $this->assertTrue($parser->isBrowser('Internet Explorer', '=', '6.0'));
     }


### PR DESCRIPTION
This PR adds two methods which allow a more intuitive way to construct a parser, e.g.:

```
Parser::fromUserAgent($request->header('User-Agent'));
```

As a side note: two redundant `instanceof` tests are removed. An instance either fails to construct or is already an instance of that class.